### PR TITLE
Set the icon_size property when creating the science icons

### DIFF
--- a/steelaxe-subscience/science.lua
+++ b/steelaxe-subscience/science.lua
@@ -183,7 +183,7 @@ do
   item.order = "z[" .. string.format("%4d", i) .. "]"
   item.subgroup = "steelaxe-subscience-pack"
   item.icon = nil
-  item.icons = { {icon = "__steelaxe-subscience__/graphics/icons/sub-science-pack64x64_" .. i .. ".png", tint = hueToRGB((i * 2) % 360)} }
+  item.icons = { {icon = "__steelaxe-subscience__/graphics/icons/sub-science-pack64x64_" .. i .. ".png", tint = hueToRGB((i * 2) % 360), icon_size = 64} }
 
   -- build recipe to build item
   local recipe = table.deepcopy(data.raw["recipe"]["automation-science-pack"])
@@ -202,7 +202,7 @@ do
         type = "unlock-recipe"
       }
     },
-    icons = { {icon = "__steelaxe-subscience__/graphics/icons/sub-science-pack64x64_" .. i .. ".png", tint = hueToRGB((i * 2) % 360)} },
+    icons = { {icon = "__steelaxe-subscience__/graphics/icons/sub-science-pack64x64_" .. i .. ".png", tint = hueToRGB((i * 2) % 360), icon_size = 64} },
     icon_size = 64,
     name = item.name,
     localised_name = item.localised_name,


### PR DESCRIPTION
While dynamically creating all the sciences, the original icon is cleared and a new one is defined with the icons array. Problem is: the icon_size property is not set. This can lead to a startup error if some other mod adds another icon to this array, say an overlay, which has the icon_size set. Seen with GDIW which tried to create a mirrored fluid recipe, adding its rotated marker to the array.

I don't know if this is also needed for the technology, but for consistency.